### PR TITLE
Change url's on some examples to always use https

### DIFF
--- a/src/pages/examples/editing.hbs
+++ b/src/pages/examples/editing.hbs
@@ -47,7 +47,7 @@ layout: example.hbs
 
   // add our feature layer to the map
   var pedestrianDistricts = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/PDX_Pedestrian_Districts/FeatureServer/0'
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/PDX_Pedestrian_Districts/FeatureServer/0'
   }).addTo(map);
 
   // variable to track the layer being edited

--- a/src/pages/examples/feature-layer-popups.hbs
+++ b/src/pages/examples/feature-layer-popups.hbs
@@ -12,7 +12,7 @@ layout: example.hbs
   L.esri.basemapLayer('Streets').addTo(map);
 
   var trees = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
   }).addTo(map);
 
   trees.bindPopup(function (evt) {

--- a/src/pages/examples/getting-service-metadata.hbs
+++ b/src/pages/examples/getting-service-metadata.hbs
@@ -22,7 +22,7 @@ layout: example.hbs
 
   L.esri.basemapLayer('Streets').addTo(map);
   var stops = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
   }).addTo(map);
 
   stops.metadata(function (error, metadata) {

--- a/src/pages/examples/labeling-features.hbs
+++ b/src/pages/examples/labeling-features.hbs
@@ -27,7 +27,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   var neighborhoods = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0',
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0',
     style: function() {
       return {
         color: '#5B7CBA',

--- a/src/pages/examples/non-mercator-projection.hbs
+++ b/src/pages/examples/non-mercator-projection.hbs
@@ -50,7 +50,7 @@ layout: example.hbs
 
   // feature layers will be requested in WGS84 (4326) and reprojected on the client
   L.esri.featureLayer({
-    url: '//services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
+    url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
     simplifyFactor: 0.5,
     precision: 5,
     style: function (feature) {

--- a/src/pages/examples/querying-feature-layers-1.hbs
+++ b/src/pages/examples/querying-feature-layers-1.hbs
@@ -70,7 +70,7 @@ layout: example.hbs
 
   L.esri.basemapLayer('Streets').addTo(map);
   var stops = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet_Transit_Stops/FeatureServer/0',
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet_Transit_Stops/FeatureServer/0',
     pointToLayer: function (geojson, latlng) {
       return L.marker(latlng, {
         icon: icons[geojson.properties.direction.toLowerCase()]

--- a/src/pages/examples/querying-feature-layers-2.hbs
+++ b/src/pages/examples/querying-feature-layers-2.hbs
@@ -11,7 +11,7 @@ layout: example.hbs
 
   L.esri.basemapLayer('Streets').addTo(map);
   var stops = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet_Transit_Stops/FeatureServer/0',
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet_Transit_Stops/FeatureServer/0',
     pointToLayer: function (geojson, latlng) {
       return L.circleMarker(latlng);
     },

--- a/src/pages/examples/renderers-plugin.hbs
+++ b/src/pages/examples/renderers-plugin.hbs
@@ -15,6 +15,6 @@ layout: example.hbs
 
   //renderer type: unique value
   L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet%20Transit%20Stops%20In%20Portland%20Neighborhoods/FeatureServer/0'
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet%20Transit%20Stops%20In%20Portland%20Neighborhoods/FeatureServer/0'
   }).addTo(map);
 </script>

--- a/src/pages/examples/simple-feature-layer.hbs
+++ b/src/pages/examples/simple-feature-layer.hbs
@@ -11,6 +11,6 @@ layout: example.hbs
 
   L.esri.basemapLayer('Streets').addTo(map);
   L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
   }).addTo(map);
 </script>

--- a/src/pages/examples/simplifying-complex-features.hbs
+++ b/src/pages/examples/simplifying-complex-features.hbs
@@ -24,7 +24,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   var zipcodes = L.esri.featureLayer({
-    url: '//services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_ZIP_Codes/FeatureServer/0',
+    url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_ZIP_Codes/FeatureServer/0',
     simplifyFactor: 0.35,
     precision: 5,
     fields: ['FID', 'ZIP', 'PO_NAME'],

--- a/src/pages/examples/styling-feature-layer-polygons.hbs
+++ b/src/pages/examples/styling-feature-layer-polygons.hbs
@@ -14,7 +14,7 @@ layout: example.hbs
   L.esri.basemapLayer('GrayLabels').addTo(map);
 
   L.esri.featureLayer({
-    url: '//services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
+    url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
     simplifyFactor: 0.5,
     precision: 5,
     style: function (feature) {

--- a/src/pages/examples/styling-feature-layer-polylines.hbs
+++ b/src/pages/examples/styling-feature-layer-polylines.hbs
@@ -24,7 +24,7 @@ layout: example.hbs
   L.esri.basemapLayer('Streets').addTo(map);
 
   var bikePaths = L.esri.featureLayer({
-    url: '//services.arcgis.com/uCXeTVveQzP4IIcx/ArcGIS/rest/services/Bike_Routes/FeatureServer/0',
+    url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/ArcGIS/rest/services/Bike_Routes/FeatureServer/0',
     style: function (feature) {
       var c,o = 0.75;
       switch (feature.properties.BIKEMODE) {

--- a/src/pages/examples/styling-heatmaps.hbs
+++ b/src/pages/examples/styling-heatmaps.hbs
@@ -18,7 +18,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   L.esri.Heat.heatmapFeatureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Graffiti_Reports/FeatureServer/0',
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Graffiti_Reports/FeatureServer/0',
     radius: 14,
     gradient: {
       0.2: '#ffffb2',

--- a/src/pages/examples/visualize-points-as-a-heatmap.hbs
+++ b/src/pages/examples/visualize-points-as-a-heatmap.hbs
@@ -18,7 +18,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   L.esri.Heat.heatmapFeatureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Graffiti_Reports/FeatureServer/0',
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Graffiti_Reports/FeatureServer/0',
     radius: 12
   }).addTo(map);
 </script>

--- a/src/pages/examples/visualizing-time-with-feature-layer.hbs
+++ b/src/pages/examples/visualizing-time-with-feature-layer.hbs
@@ -64,7 +64,7 @@ layout: example.hbs
   L.esri.basemapLayer('GrayLabels').addTo(map);
 
   var reports = L.esri.Heat.heatmapFeatureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Graffiti_Reports/FeatureServer/0',
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Graffiti_Reports/FeatureServer/0',
     timeField: 'CreatedDate',
     from: new Date(startTimeInput.value),
     to: new Date(endTimeInput.value),

--- a/src/pages/examples/zooming-to-all-features-1.hbs
+++ b/src/pages/examples/zooming-to-all-features-1.hbs
@@ -12,7 +12,7 @@ layout: example.hbs
   L.esri.basemapLayer('Streets').addTo(map);
 
   var trees = L.esri.featureLayer({
-    url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
+    url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
   }).addTo(map);
 
   trees.query().bounds(function (error, latlngbounds) {


### PR DESCRIPTION
- Some services used on examples are not responding to http connections
  anymore (e.g Heritage_Trees_Portland, Graffiti_Reports,
  Trimet_Transit_Stops, etc.). Due to it some examples are not working on http connections (e.g. simple-feature-layer, querying-feature-layers-1, etc.)
- Also changed url's on services that are responding to http requests
  (USA_Congressional_Districts, USA_ZIP_Codes and Bike_Routes)
